### PR TITLE
Add traj use_synonym

### DIFF
--- a/openap/kinematic.py
+++ b/openap/kinematic.py
@@ -36,7 +36,7 @@ wrap_synonym = pd.read_csv(file_synonym)
 class WRAP(object):
     """Construct the kinematic model of the aicraft."""
 
-    def __init__(self, ac, **kwargs):
+    def __init__(self, ac, use_synonym=False, **kwargs):
         """Initialize WRAP object.
 
         Args:
@@ -47,7 +47,7 @@ class WRAP(object):
 
         self.ac = ac.lower()
 
-        self.use_synonym = kwargs.get("use_synonym", False)
+        self.use_synonym = use_synonym
 
         wrap_files = glob.glob(dir_wrap + "*.txt")
         ac_wrap_available = [s[-8:-4].lower() for s in wrap_files]

--- a/openap/traj/gen.py
+++ b/openap/traj/gen.py
@@ -32,7 +32,7 @@ import numpy as np
 class Generator(object):
     """Generate trajectory using WRAP model."""
 
-    def __init__(self, ac, eng=None):
+    def __init__(self, ac, eng=None, use_synonym=False):
         """Intitialize the generator.
 
         Args:
@@ -46,7 +46,7 @@ class Generator(object):
         super(Generator, self).__init__()
 
         self.ac = ac
-        self.acdict = prop.aircraft(self.ac)
+        self.acdict = prop.aircraft(self.ac, use_synonym)
 
         if eng is None:
             self.eng = self.acdict["engine"]["default"]
@@ -54,7 +54,7 @@ class Generator(object):
             self.eng = eng
         self.engdict = prop.engine(self.eng)
 
-        self.wrap = WRAP(self.ac)
+        self.wrap = WRAP(self.ac, use_synonym)
         # self.thrust = Thrust(self.ac, self.eng)
         # self.drag = Drag(self.ac)
         # self.fuelflow = Thrust(self.ac, self.eng)


### PR DESCRIPTION
Recently, i used openap to build own project and found some little feature should be improved. In file `./openap/traj/gen.py` generate trajectory using WRAP model without `use_synonym` option. I'd like to improve it when others use `Generator` class more easily and optionally!
![image](https://github.com/user-attachments/assets/290efc2e-09a2-47ab-8175-3e709ea34d6f)

thanks for your reply!
